### PR TITLE
Fix login problem

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -10,7 +10,7 @@ function getSessionId() {
 
 // ---------- Utilities -----------
 function getProperties ($http, $location) {
-    $http.get('resources/config.json')
+    return $http.get('resources/config.json')
         .success(function (response) {
             var pcaServiceUrl = angular.toJson(response.confServer.pcaServiceUrl, true);
             var schedulerRestUrl = angular.toJson(response.confServer.schedulerRestUrl, true);
@@ -41,16 +41,16 @@ function getProperties ($http, $location) {
         });
 }
 
-var isSessionValide = function ($http, sessionId) {
-    if (localStorage['rmRestUrl']) {
-        return $http.get(rmRestUrl + "logins/sessionid/" + sessionId + "/userdata/").then(function(result){
-            return result.data !=""
+var isSessionValide = function ($http, sessionId, $location) {
+    console.log("rmRestUrl before=" + localStorage['rmRestUrl']);
+    return getProperties($http, $location).then(function () {
+        var rmRestUrl = localStorage['rmRestUrl'];
+        console.log("rmRestUrl after=" + rmRestUrl);
+        var userDataUrl = JSON.parse(rmRestUrl) + "logins/sessionid/" + sessionId + "/userdata/";
+        return $http.get(userDataUrl).then(function(result) {
+            return result.data !="";
         });
-    }
-    else {
-        console.log("sessionid is not valid");
-        return false;
-    }
+    });
 };
 
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -42,10 +42,8 @@ function getProperties ($http, $location) {
 }
 
 var isSessionValide = function ($http, sessionId, $location) {
-    console.log("rmRestUrl before=" + localStorage['rmRestUrl']);
     return getProperties($http, $location).then(function () {
         var rmRestUrl = localStorage['rmRestUrl'];
-        console.log("rmRestUrl after=" + rmRestUrl);
         var userDataUrl = JSON.parse(rmRestUrl) + "logins/sessionid/" + sessionId + "/userdata/";
         return $http.get(userDataUrl).then(function(result) {
             return result.data !="";

--- a/app/templates_versions/community/config.js
+++ b/app/templates_versions/community/config.js
@@ -131,7 +131,6 @@ angular
             }
             var myDataPromise = isSessionValide($http, getSessionId(), $location);
             myDataPromise.then(function(result) {
-                console.log("isSessionValide ? " + result);
                 if (!result && $location.$$url != '/login') {
                     event.preventDefault();
                     $rootScope.$broadcast('event:StopRefreshing');

--- a/app/templates_versions/community/config.js
+++ b/app/templates_versions/community/config.js
@@ -123,11 +123,15 @@ angular
     .module('inspinia')
     .run(function($rootScope, $state, $http, $location) {
         $rootScope.$on('$locationChangeStart', function(event) {
-            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] || !localStorage['notificationServiceUrl'] ||
-                !localStorage['catalogServiceUrl'] || !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] || !localStorage['configViews'])
+            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] ||
+                !localStorage['notificationServiceUrl'] || !localStorage['catalogServiceUrl'] ||
+                !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] ||
+                !localStorage['configViews'] || !localStorage['rmRestUrl']) {
                 getProperties($http, $location);
-            var myDataPromise = isSessionValide($http, getSessionId());
+            }
+            var myDataPromise = isSessionValide($http, getSessionId(), $location);
             myDataPromise.then(function(result) {
+                console.log("isSessionValide ? " + result);
                 if (!result && $location.$$url != '/login') {
                     event.preventDefault();
                     $rootScope.$broadcast('event:StopRefreshing');

--- a/app/templates_versions/enterprise/config.js
+++ b/app/templates_versions/enterprise/config.js
@@ -131,11 +131,15 @@ angular
     .module('inspinia')
     .run(function($rootScope, $state, $http, $location) {
         $rootScope.$on('$locationChangeStart', function(event) {
-            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] || !localStorage['notificationServiceUrl'] ||
-                !localStorage['catalogServiceUrl'] || !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] || !localStorage['configViews'])
+            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] ||
+                !localStorage['notificationServiceUrl'] || !localStorage['catalogServiceUrl'] ||
+                !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] ||
+                !localStorage['configViews'] || !localStorage['rmRestUrl']) {
                 getProperties($http, $location);
-            var myDataPromise = isSessionValide($http, getSessionId());
+            }
+            var myDataPromise = isSessionValide($http, getSessionId(), $location);
             myDataPromise.then(function(result) {
+                console.log("isSessionValide ? " + result);
                 if (!result && $location.$$url != '/login') {
                     event.preventDefault();
                     $rootScope.$broadcast('event:StopRefreshing');


### PR DESCRIPTION
The fetch of the properties wasn't chained properly to the login, so the login code could execute before the client even get the properties like the url to log into. My fix forces login code to execute only once the getProperties has finished executing.