### PR TITLE
Use minified library files for faster build

### DIFF
--- a/app/templates_versions/common/index.html
+++ b/app/templates_versions/common/index.html
@@ -49,9 +49,9 @@
     <link rel="stylesheet" type="text/css" href="bower_components/codemirror/addon/hint/show-hint.css">
 
     <!-- angular-gantt-->
-    <link rel="stylesheet" type="text/css" href="node_modules/angular-gantt/dist/angular-gantt.css" />
-    <link rel="stylesheet" type="text/css" href=node_modules/angular-gantt/dist/angular-gantt-plugins.css" />
-    <link rel="stylesheet" type="text/css" href="node_modules/angular-gantt/dist/angular-gantt-core.css" />
+    <link rel="stylesheet" type="text/css" href="node_modules/angular-gantt/dist/angular-gantt.min.css" />
+    <link rel="stylesheet" type="text/css" href=node_modules/angular-gantt/dist/angular-gantt-plugins.min.css" />
+    <link rel="stylesheet" type="text/css" href="node_modules/angular-gantt/dist/angular-gantt-core.min.css" />
     <link rel="stylesheet" type="text/css" href="node_modules/angular-ui-tree/dist/angular-ui-tree.min.css" />
 
     <!-- Main Inspinia CSS files -->
@@ -83,28 +83,27 @@
     <!-- build:js(.) scripts/vendor.js -->
 
     <!-- jQuery and Bootstrap -->
-    <script src="bower_components/jquery/dist/jquery.js"></script>
-    <!--script src="bower_components/jquery-ui/jquery-ui.js"></script-->
-    <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
 
     <!-- MetsiMenu -->
-    <script src="bower_components/metisMenu/dist/metisMenu.js"></script>
+    <script src="bower_components/metisMenu/dist/metisMenu.min.js"></script>
 
     <!-- SlimScroll -->
-    <script src="bower_components/jquery-slimscroll/jquery.slimscroll.js"></script>
+    <script src="bower_components/jquery-slimscroll/jquery.slimscroll.min.js"></script>
 
-    <!-- Peace JS -->
+    <!-- Peace JS : page loading bar -->
     <script src="bower_components/pace/pace.js"></script>
 
     <!-- Angular scripts-->
-    <script src="bower_components/angular/angular.js"></script>
-    <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
-    <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+    <script src="bower_components/angular/angular.min.js"></script>
+    <script src="bower_components/angular-ui-router/release/angular-ui-router.min.js"></script>
+    <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
     <script src="bower_components/angular-filter/dist/angular-filter.min.js"></script>
 
     <!-- Angular Dependiences -->
-    <script src="bower_components/angular-resource/angular-resource.js"></script>
-    <script src="bower_components/angular-spring-data-rest/dist/angular-spring-data-rest.js"></script>
+    <script src="bower_components/angular-resource/angular-resource.min.js"></script>
+    <script src="bower_components/angular-spring-data-rest/dist/angular-spring-data-rest.min.js"></script>
     <script src="bower_components/angular-toArrayFilter/toArrayFilter.js"></script>
     <script src="bower_components/ngSweetAlert/SweetAlert.min.js"></script>
     <script src="bower_components/sweetalert/dist/sweetalert.min.js"></script>
@@ -112,9 +111,7 @@
     <script src="bower_components/jquery-slimscroll/jquery.slimscroll.min.js"></script>
     <script src="bower_components/angular-css/angular-css.min.js"></script>
     <script src='bower_components/angular-cron-gen/build/cron-gen.min.js'></script>
-    <script src='bower_components/moment/moment.js'></script>
-    <script src='bower_components/moment/locale/*.js'></script>
-    <script src='bower_components/moment/min/moment-with-locales.js'></script>
+    <script src='bower_components/moment/min/moment-with-locales.min.js'></script>
     <script src='bower_components/angular-moment-picker/dist/angular-moment-picker.min.js'></script>
     <script src="bower_components/angular-bootstrap-calendar/dist/js/angular-bootstrap-calendar-tpls.min.js"></script>
     <script src="bower_components/codemirror/lib/codemirror.js"></script>
@@ -158,13 +155,13 @@
     <script src="bower_components/codemirror/mode/xml/xml.js"></script>
     <script src="bower_components/codemirror/mode/yaml/yaml.js"></script>
     <script src="bower_components/codemirror/mode/markdown/markdown.js"></script>
-    <script src="node_modules/angular-moment/angular-moment.js"></script>
+    <script src="node_modules/angular-moment/angular-moment.min.js"></script>
     <script src="node_modules/css-element-queries/src/ElementQueries.js"></script>
     <script src="node_modules/css-element-queries/src/ResizeSensor.js"></script>
     <script src="node_modules/angular-gantt/dist/angular-gantt.js"></script>
     <script src="node_modules/angular-gantt/dist/angular-gantt-plugins.js"></script>
     <script src="node_modules/angular-gantt/dist/angular-gantt-core.js"></script>
-    <script src="node_modules/angular-ui-tree/dist/angular-ui-tree.js"></script>
+    <script src="node_modules/angular-ui-tree/dist/angular-ui-tree.min.js"></script>
     <script src="node_modules/moment-precise-range-plugin/moment-precise-range.js"></script>
     <script src="node_modules/html2canvas/dist/html2canvas.min.js"></script>
 


### PR DESCRIPTION
Using minified libraries makes the build faster, but only 2 seconds so it isn't worth merging into master. That's why I created a branch. 
Some libraries don't have minified versions (like code mirror) and I noticed that for others it makes the build longer (angular gantt).