### PR TITLE
Add ui-sortable dependency for Job Analytics

### DIFF
--- a/app/templates_versions/common/index.html
+++ b/app/templates_versions/common/index.html
@@ -127,6 +127,7 @@
     <script src='bower_components/moment/min/moment-with-locales.js'></script>
     <script src='bower_components/angular-moment-picker/dist/angular-moment-picker.min.js'></script>
     <script src="bower_components/angular-bootstrap-calendar/dist/js/angular-bootstrap-calendar-tpls.min.js"></script>
+    <script src="bower_components/angular-ui-sortable/sortable.min.js"></script>
     <script src="bower_components/codemirror/lib/codemirror.js"></script>
     <script src="bower_components/angular-ui-codemirror/ui-codemirror.js"></script>
     <script src="bower_components/codemirror/addon/display/autorefresh.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,8 @@
     "angular-cron-gen": "^0.0.26",
     "angular-moment-picker": "moment-picker#^0.10.2",
     "angular-bootstrap-calendar": "^1.0.0",
-    "angular-ui-codemirror": "^0.3.0"
+    "angular-ui-codemirror": "^0.3.0",
+    "angular-ui-sortable": "^0.14.4"
   },
   "resolutions": {
     "jquery": "~2.1.4",


### PR DESCRIPTION
In this PR, we add the angular-ui-sortable (jquery-ui wrapper) to be used in Job Analytics