### PR TITLE
Update Angular Bootstrap version to latest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "angular-resource": "^1.5.1",
     "angular-ui-router": "~0.2.15",
     "bootstrap": "~3.3.6",
-    "angular-bootstrap": "~1.1.2",
+    "angular-bootstrap": "^2.5.0",
     "moment": "^2.20.1",
     "animate.css": "~3.4.0",
     "angular": "1.X",


### PR DESCRIPTION
Some dependencies require a recent version of angular-bootstrap
This PR updates its version to the latest.
Tested for compilation compatibility and has no apparent regression.