### PR TITLE
Add doc link to sidebar, update styles and add JA dependencies

### DIFF
--- a/app/styles/dashboard-style.css
+++ b/app/styles/dashboard-style.css
@@ -174,6 +174,7 @@
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
     display: inline-flex;
+    border-radius: 4px;
 }
 
 .btn-group.pa-shortcuts {

--- a/app/templates_versions/common/index.html
+++ b/app/templates_versions/common/index.html
@@ -186,8 +186,6 @@
     <script src="node_modules/chart.js/dist/Chart.bundle.js"></script>
     <script src="node_modules/angular-chart.js/dist/angular-chart.min.js"></script>
     <script src="node_modules/angular-ui-grid/ui-grid.js"></script>
-    <script src="node_modules/pdfmake/build/pdfmake.js"></script>
-    <script src="node_modules/pdfmake/build/vfs_fonts.js"></script>
     <script src="node_modules/ui-select/dist/select.js"></script>
 
     <!--!DO NOT EDIT! The following code related to subviews is automatically generated with grunt build. You can't modify it from here.

--- a/app/templates_versions/common/navigation.html
+++ b/app/templates_versions/common/navigation.html
@@ -36,6 +36,11 @@
                     <a ui-sref="portal.subview4" style="background-color: #002d66"><i class="fa fa-desktop"></i> <span class="nav-label">Notification portal</span> </a>
                 </li>
                 <!-- endSubviews-->
+
+                <!-- Documentation Link-->
+                <li style="position: fixed;bottom: 0px;left: 0px;width: 220px;height: 39px;">
+                    <a href="{{docLink}}" target="_blank" style="color: #002d66; background-color:rgba(255,255,255,0.5);padding: 11px 15px;"><i class="fa fa-info-circle"></i> <span class="nav-label" style="display:-webkit-inline-box;" id="nav-span-notification">Documentation</span> </a>
+                </li>
             </ul>
         </div>
     </nav>

--- a/app/templates_versions/community/subviews.json
+++ b/app/templates_versions/community/subviews.json
@@ -59,8 +59,9 @@
         "secondaryHtmlFiles": [
             "templates/advanced_search_hints.html",
             "templates/ui_grid_filter_date.html",
-            "templates/ui_grid_filter_time.html",
-            "templates/ui_grid_filter_input.html"
+            "templates/ui_grid_filter_input.html",
+            "templates/ui_grid_filter_select.html",
+            "templates/ui_grid_filter_time.html"
         ],
         "notAvailablePage": "page_not_available_job-analytics.html",
         "jsFiles": [

--- a/app/templates_versions/enterprise/subviews.json
+++ b/app/templates_versions/enterprise/subviews.json
@@ -59,8 +59,9 @@
         "secondaryHtmlFiles": [
             "templates/advanced_search_hints.html",
             "templates/ui_grid_filter_date.html",
-            "templates/ui_grid_filter_time.html",
-            "templates/ui_grid_filter_input.html"
+            "templates/ui_grid_filter_input.html",
+            "templates/ui_grid_filter_select.html",
+            "templates/ui_grid_filter_time.html"
         ],
         "notAvailablePage": "page_not_available_job-analytics.html",
         "jsFiles": [

--- a/app/views/common/content.html
+++ b/app/views/common/content.html
@@ -1,5 +1,5 @@
 <!-- Wrapper-->
-<div id="wrapper" style="background-color: #f47932" ng-click="hideContextualMenu()" ng-wheel="hideContextualMenu()">
+<div id="wrapper" style="background-color: #E86D1F" ng-click="hideContextualMenu()" ng-wheel="hideContextualMenu()">
 
 
     <!-- Navigation -->

--- a/app/views/common/topnavbar.html
+++ b/app/views/common/topnavbar.html
@@ -3,7 +3,7 @@
         <ul class="nav navbar-nav navbar-right" style="display: inline-flex;">
             <li style="padding-right: 5px;">
                 <div class="btn-group pa-shortcuts">
-                    <a class="btn btn-small btn-default active pa-shortcuts" href="/automation-dashboard/" style="color:#333;border-color: #ccc;padding:5px">
+                    <a class="btn btn-small btn-default active pa-shortcuts" href="/automation-dashboard/" style="color:#fff;border-color: #ccc;padding:5px; background-color: #E86D1F;">
                         <img src="styles/patterns/automation_dashboard_30.png" style="height:25px;padding-left: 4px;padding-right: 4px;">
                         <div class="pa-shortcut" style="width: 154px;">Automation Dashboard</div>
                     </a>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "moment": "^2.22.2",
     "moment-duration-format": "^2.2.2",
     "moment-precise-range-plugin": "^1.3.0",
-    "pdfmake": "^0.1.54",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {


### PR DESCRIPTION
In this PR we:

- Add a documentation link at the bottom of the left sidebar.
- Apply a corporate-orange background to Automation-Dashboard button at the top nabber
- Update the false corporate-orange color used everywhere with the *true* corporate-orange #E86D1F
- Add a dependency script for Job Analytics Portal
- Remove unused dependencies from Job Analytics