### PR TITLE
feat: Add third-party-credentials modal

### DIFF
--- a/app/scripts/modals/third-party-credential-modal-controller.js
+++ b/app/scripts/modals/third-party-credential-modal-controller.js
@@ -1,0 +1,39 @@
+angular.module('workflow-variables', []).controller('ThirdPartyCredentialModalCtrl', function($scope, $http, $uibModalInstance) {
+    var schedulerRestUrl = JSON.parse(localStorage.schedulerRestUrl);
+
+    $scope.refreshCredentials = function () {
+        var url = schedulerRestUrl + 'credentials/';
+        $http.get(url, {headers: {'sessionID': getSessionId()}})
+            .success(function (response) {
+                $scope.credentialKeys = response.sort();
+            })
+            .error(function (response) {
+                console.error('Error while querying scheduling api on URL ' + url + ':', JSON.stringify(response));
+            });
+    }
+
+    $scope.removeThirdPartyCredential = function (credKey) {
+        var url = schedulerRestUrl + 'credentials/' + encodeURIComponent(credKey);
+        $http.delete(url, {headers: {'sessionID': getSessionId()}})
+            .success($scope.refreshCredentials)
+            .error(function (response) {
+                console.error('Error while querying scheduling api on URL ' + url + ':', JSON.stringify(response));
+            });
+    }
+
+    $scope.addThirdPartyCredential = function (credKey, credValue) {
+        var url = schedulerRestUrl + 'credentials/' + encodeURIComponent(credKey);
+        var data = 'value=' + encodeURIComponent(credValue);
+        $http.post(url, data, {headers: {'sessionID': getSessionId(), 'Content-Type': 'application/x-www-form-urlencoded'}})
+            .success($scope.refreshCredentials)
+            .error(function (response) {
+                console.error('Error while querying scheduling api on URL ' + url + ':', JSON.stringify(response));
+            });
+    }
+
+    $scope.cancel = function () {
+        $uibModalInstance.dismiss('cancel');
+    }
+
+    $scope.refreshCredentials();
+});

--- a/app/styles/dashboard-style.css
+++ b/app/styles/dashboard-style.css
@@ -360,6 +360,19 @@
     border-radius: 6px 0 6px 6px;
 }
 
+.third-party-credential-modal.modal {
+    z-index: 2060 !important;
+}
+
+#add-3rd-party-cred-table td {
+    padding-left:10px;
+    padding-right:10px;
+}
+
+#new-cred-key.ng-invalid:focus {
+    border-color: #ed5565 !important;
+}
+
 @media screen and (min-width:1625px) {
     .small-text {
         display: none;

--- a/app/templates_versions/common/index.html
+++ b/app/templates_versions/common/index.html
@@ -211,6 +211,7 @@ See 'replace' task in Gruntfile.js and subviews definition in community/enterpri
     <script src="scripts/login.js"></script>
     <script src="scripts/main.js"></script>
     <script src="scripts/utils.js"></script>
+    <script src="scripts/modals/third-party-credential-modal-controller.js"></script>
     <!-- app Layout script -->
 
 

--- a/app/templates_versions/community/subviews.json
+++ b/app/templates_versions/community/subviews.json
@@ -8,8 +8,7 @@
         "secondaryHtmlFiles": [
             "modals/catalog_object_edition.html",
             "modals/submit_workflow.html",
-            "modals/workflow_visualization.html",
-            "modals/third_party_credentials.html"
+            "modals/workflow_visualization.html"
         ],
         "notAvailablePage": "page_not_available.html",
         "jsFiles": [
@@ -20,8 +19,7 @@
             "scripts/submitWorkflowModalGCP.js",
             "scripts/editObjectModalGCP.js",
             "scripts/workflowVisualizationModalGCP.js",
-            "scripts/workflowVisualizationController.js",
-            "scripts/thirdPartyCredentialModalGCP.js"
+            "scripts/workflowVisualizationController.js"
         ],
         "angularModuleName": "gcp-rest",
         "cssFile": "gcportal_custom_style.css",

--- a/app/templates_versions/enterprise/subviews.json
+++ b/app/templates_versions/enterprise/subviews.json
@@ -8,8 +8,7 @@
         "secondaryHtmlFiles": [
             "modals/catalog_object_edition.html",
             "modals/submit_workflow.html",
-            "modals/workflow_visualization.html",
-            "modals/third_party_credentials.html"
+            "modals/workflow_visualization.html"
         ],
         "notAvailablePage": "page_not_available.html",
         "jsFiles": [
@@ -20,8 +19,7 @@
             "scripts/submitWorkflowModalGCP.js",
             "scripts/editObjectModalGCP.js",
             "scripts/workflowVisualizationModalGCP.js",
-            "scripts/workflowVisualizationController.js",
-            "scripts/thirdPartyCredentialModalGCP.js"
+            "scripts/workflowVisualizationController.js"
         ],
         "angularModuleName": "gcp-rest",
         "cssFile": "gcportal_custom_style.css",

--- a/app/views/modals/third_party_credentials.html
+++ b/app/views/modals/third_party_credentials.html
@@ -1,0 +1,63 @@
+<div class="inmodal" ng-class="third-party-credential-modal">
+
+    <div class="modal-header">
+        <button type="button" class="close close-modal-btn" ng-click="cancel()">×</button>
+        <h4 class="modal-title"> {{'Third-Party Credentials'|translate}} </h4>
+    </div>
+
+    <div class="modal-body">
+        <div style="overflow-x: hidden; overflow-y: scroll; height: 280px;">
+            <table id="third-party-credential-table" class="table table-hover">
+                <thead>
+                <tr>
+                    <th width="40%">{{'Key'|translate}}</th>
+                    <th width="40%">{{'Credential'|translate}}</th>
+                    <th width="20%"></th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr ng-repeat="key in credentialKeys">
+                    <td style="word-break: break-all;">{{key}}</td>
+                    <td>******</td>
+                    <td>
+                        <button id={{key}} class="btn btn-danger fa fa-trash"
+                                ng-click="removeThirdPartyCredential(key)">
+                        </button>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <div>
+            <!--            to create a new credential, its key mustn't be empty. -->
+            <form name="newCredForm" class="form-group"
+                  ng-class="{'has-error': newCredForm.credKey.$invalid && newCredForm.credKey.$dirty}"
+                  ng-submit="addThirdPartyCredential(credKey, credValue)">
+                <table id="add-3rd-party-cred-table" style="margin-top: 25px">
+                    <tr>
+                        <td width="40%"><label for="new-cred-key">{{'Key'|translate}}:</label></td>
+                        <td width="40%"><label for="new-cred-value">{{'Credential'|translate}}:</label></td>
+                        <td width="20%"></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input type="text" id="new-cred-key" name="credKey" ng-model="credKey"
+                                   class="textareavalues form-control" required pattern=".*\S+.*"
+                                   title="{{'The credential key should not contain only white spaces.'|translate}}"/>
+                        </td>
+                        <td><input type="password" id="new-cred-value" name="credValue" ng-model="credValue"
+                                   class="textareavalues form-control" autocomplete="new-password"/></td>
+                        <td>
+                            <button id="add-third-party-credential-button" class="btn btn-success"> {{'Add'|translate}}
+                            </button>
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        <button type="button" class="btn btn-white" ng-click="cancel()">{{'Close'|translate}}</button>
+    </div>
+</div>


### PR DESCRIPTION
Moving the third-party-credentials management modal from generic-catalog-portal to the automation-dashboard, so that it can easily reused in different subviews (e.g., catalog-portal, workflow-automation, cloud-automation, calendar-associations).
