### PR TITLE
Fix AD

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -420,10 +420,9 @@ module.exports = function (grunt) {
         jsbeautifier: {
             files: [
                 '<%= inspinia.app %>/scripts/config.js',
-                '<%= inspinia.app %>/views/common/navigation.html',
                 '<%= inspinia.app %>/scripts/app.js',
-                '<%= inspinia.app %>/index.html',
-                '<%= inspinia.app %>/<%= inspinia.conf %>/{,*/}*.*'
+                '<%= inspinia.app %>/<%= inspinia.conf %>/{,*/}*.*',
+                '!<%= inspinia.app %>/{,*/}{,*/}*.html'
             ],
             options: {
             }
@@ -449,7 +448,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: '<%= inspinia.dist %>',
-                    src: ['*.html', 'views/{,*/}*.html', '!index.html', '!views/common/navigation.html'],
+                    src: ['*.html', 'views/{,*/}*.html'],
                     dest: '<%= inspinia.dist %>'
                 }]
             }

--- a/app/templates_versions/common/app.js
+++ b/app/templates_versions/common/app.js
@@ -4,35 +4,39 @@
  */
 (function() {
     angular.module('inspinia', [
-            'ui.router', // Routing
-            'ui.bootstrap', // Bootstrap
-            'main',
-            'angularMoment',
-            'angular-cron-gen',
-            'moment-picker',
-            'mwl.calendar',
-            //!DO NOT EDIT! The following code related to subviews is automatically generated with grunt build. You can't modify it from here.
-            //See 'replace' task in Gruntfile.js and subviews definition in enterpriseSubviews.json.
+        'ui.router', // Routing
+        'ui.bootstrap', // Bootstrap
+        'main',
+        'angularMoment',
+        'angular-cron-gen',
+        'moment-picker',
+        'mwl.calendar',
+        //!DO NOT EDIT! The following code related to subviews is automatically generated with grunt build. You can't modify it from here.
+        //See 'replace' task in Gruntfile.js and subviews definition in enterpriseSubviews.json.
 
-            //beginSubviewsModules
+        //beginSubviewsModules
 
-            //endSubviewsModules
-            'angularCSS',
-            'ui.codemirror',
-            'gantt',
-            'gantt.tooltips',
-            'ui.tree',
-            'gantt.tree',
-            'gantt.groups',
-            'gantt.corner'
+        //endSubviewsModules
+        'angularCSS',
+        'ui.codemirror',
+        'gantt',
+        'gantt.tooltips',
+        'ui.tree',
+        'gantt.tree',
+        'gantt.groups',
+        'gantt.corner'
+    ])
+        .config(['momentPickerProvider',
+            function(momentPickerProvider) {
+                momentPickerProvider.options({
+                    minutesFormat: 'HH:mm'
+                });
+            }
         ])
-        .config(['momentPickerProvider', function(momentPickerProvider) {
-            momentPickerProvider.options({
-                minutesFormat: 'HH:mm'
-            });
-        }])
-        .config(['calendarConfig', function(calendarConfig) {
-            calendarConfig.allDateFormats.moment.date.hour = 'HH:mm';
-            calendarConfig.showTimesOnWeekView = true;
-        }])
+        .config(['calendarConfig',
+            function(calendarConfig) {
+                calendarConfig.allDateFormats.moment.date.hour = 'HH:mm';
+                calendarConfig.showTimesOnWeekView = true;
+            }
+        ])
 })();

--- a/app/templates_versions/common/config.js
+++ b/app/templates_versions/common/config.js
@@ -6,6 +6,7 @@
  * Initial there are written stat for all view in theme.
  *
  */
+
 function config($stateProvider, $urlRouterProvider) {
 
     $stateProvider
@@ -55,10 +56,7 @@ angular
     .module('inspinia')
     .run(function($rootScope, $state, $http, $location) {
         $rootScope.$on('$locationChangeStart', function(event) {
-            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] ||
-                !localStorage['notificationServiceUrl'] || !localStorage['catalogServiceUrl'] ||
-                !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] ||
-                !localStorage['configViews'] || !localStorage['rmRestUrl'] || !localStorage['restUrl']) {
+            if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] || !localStorage['notificationServiceUrl'] || !localStorage['catalogServiceUrl'] || !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] || !localStorage['configViews'] || !localStorage['rmRestUrl'] || !localStorage['restUrl']) {
                 getProperties($http, $location);
             }
             var myDataPromise = isSessionValide($http, getSessionId(), $location);


### PR DESCRIPTION
-We exclude `html` files from being formatted by `jsbeautifier` as it introduces bad formatting operations. In any case, `jsbeautifier` is not designed to beautify `html` but rather `js` scripts.

-Apply `beautification` to the exising `js` files.

-Remove excluded files from `htmlmin` grunt task.