### PR TITLE
fix: add utils func to check if a variable needs special UI

### DIFF
--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -6,6 +6,7 @@ function UtilsFactory($window) {
             win.focus();
         }
     }
+
     function updateCursor(isWaiting) {
         var body = angular.element(document).find('body');
         if (isWaiting) {
@@ -13,10 +14,22 @@ function UtilsFactory($window) {
         } else {
             body.removeClass('waiting');
         }
+    }
+
+    // check whether the variable needs a special UI (i.e., it's not simply showing its value with an inputbox)
+    // For example, if the variable is the type 'pa:boolean', 'pa:list', or 'pa:datetime' etc, the function return true
+    var specialUIModel = ['pa:boolean', 'pa:list', 'pa:datetime', 'pa:hidden', 'pa:global_file', 'pa:user_file', 'pa:optional_global_file', 'pa:optional_user_file', 'pa:credential'];
+    function isSpecialUIModel(variable) {
+        function matchTargetModel(targetModel) {
+            return variable.model.toLowerCase().indexOf(targetModel) != -1;
+        }
+        var index = specialUIModel.findIndex(matchTargetModel);
+        return index != -1;
     };
 
     return {
         openJobInSchedulerPortal : openJobInSchedulerPortal,
+        isSpecialUIModel: isSpecialUIModel,
         updateCursor : function(isWaiting){
             return updateCursor(isWaiting);
         }

--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -1,4 +1,6 @@
 function UtilsFactory($window) {
+    var specialUIModel = ['pa:boolean', 'pa:list', 'pa:datetime', 'pa:hidden', 'pa:global_file', 'pa:user_file', 'pa:optional_global_file', 'pa:optional_user_file', 'pa:credential'];
+
     function openJobInSchedulerPortal(jobId) {
         if (jobId) {
             var url = JSON.parse(localStorage.schedulerPortalUrl)+ '/?job=' + jobId;
@@ -18,13 +20,8 @@ function UtilsFactory($window) {
 
     // check whether the variable needs a special UI (i.e., it's not simply showing its value with an inputbox)
     // For example, if the variable is the type 'pa:boolean', 'pa:list', or 'pa:datetime' etc, the function return true
-    var specialUIModel = ['pa:boolean', 'pa:list', 'pa:datetime', 'pa:hidden', 'pa:global_file', 'pa:user_file', 'pa:optional_global_file', 'pa:optional_user_file', 'pa:credential'];
     function isSpecialUIModel(variable) {
-        function matchTargetModel(targetModel) {
-            return variable.model.toLowerCase().indexOf(targetModel) != -1;
-        }
-        var index = specialUIModel.findIndex(matchTargetModel);
-        return index != -1;
+        return specialUIModel.findIndex(function(targetModel){return variable.model.toLowerCase().indexOf(targetModel) != -1;}) != -1;
     };
 
     return {

--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -21,7 +21,9 @@ function UtilsFactory($window) {
     // check whether the variable needs a special UI (i.e., it's not simply showing its value with an inputbox)
     // For example, if the variable is the type 'pa:boolean', 'pa:list', or 'pa:datetime' etc, the function return true
     function isSpecialUIModel(variable) {
-        return specialUIModel.findIndex(function(targetModel){return variable.model.toLowerCase().indexOf(targetModel) != -1;}) != -1;
+        return -1 !== specialUIModel.findIndex(function (targetModel) {
+            return variable.model.toLowerCase().indexOf(targetModel) !== -1;
+        });
     };
 
     return {


### PR DESCRIPTION
Fix the bug when check whether a variable needs special UI (i.e., it's not simply showing its value with an inputbox, for example, the variables with the model 'pa:boolean', 'pa:list', or 'pa:datetime' etc) during workflow submission, the variable model may only contain the specific model keyword instead of exactly the same.

For example, a list variable may be defined as `PA:LIST(a,b,c)` instead of `PA:LIST`. The previous commits in the subviews introduce the bug: 
- https://bitbucket.org/activeeon/generic-catalog-portal/pull-requests/146/improve-file-browser-modal/diff
- https://bitbucket.org/activeeon/job-planner-portal/pull-requests/266/improve-file-browser-modal/diff
- https://bitbucket.org/activeeon/cloud-automation/pull-requests/250/improve-file-browser-modal/diff 