### PR TITLE
Add .gitattributes file to prevent git from formatting OS specific

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+*.html eol=lf
+*.gradle eol=lf
+*.sh eol=lf
+*.md eol=lf
+*.less eol=lf
+*.js eol=lf
+*.css eol=lf
+*.json eol=lf
+
+*.bat eol=crlf
+
+*.png binary
+*.jpg binary


### PR DESCRIPTION
line breaks.