### PR TITLE
Fix service endpoint links without protocol

### DIFF
--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -149,6 +149,10 @@ function UtilsFactory($window, $uibModal, $filter, $cookies, SweetAlert) {
     }
 
    function openEndpoint(url) {
+       // Add default protocol if it is not provided (when launching locally)
+       if (!url.match(/^[a-zA-Z]+:\/\//)) {
+           url = window.location.protocol + '//' + url;
+       }
         var parsedUrl = new URL(url);
 
         if (parsedUrl.pathname.includes('cloud-automation-service/services/')) {


### PR DESCRIPTION
When opening endpoints from a local installation, no protocol is added to 'localhost'.
This PR fixes this scenario by adding the actual protocol detected by the browser to the endpoint link (otherwise, it wouldn't work)