### PR TITLE
Add HTML templates for WE dropdowns

### DIFF
--- a/app/styles/dashboard-style.css
+++ b/app/styles/dashboard-style.css
@@ -641,3 +641,17 @@
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483 !important;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483 !important;
 }
+
+.text-inspinia {
+    color: #18a689;
+}
+
+.dropdown-menu-right {
+    right: 0!important;
+    left: auto!important;
+}
+
+.dropdown-menu-left {
+    right: auto!important;
+    left: 0!important;
+}

--- a/app/templates_versions/community/subviews.json
+++ b/app/templates_versions/community/subviews.json
@@ -9,6 +9,11 @@
             "modals/result_map_window_wf_automation.html",
             "modals/job_output_window_wf_automation.html",
             "workflow-execution/templates/catalog-view.html",
+            "workflow-execution/templates/job-actions-dropdown.html",
+            "workflow-execution/templates/job-interfaces-dropdown.html",
+            "workflow-execution/templates/job-results-dropdown.html",
+            "workflow-execution/templates/job-service-dropdown.html",
+            "workflow-execution/templates/job-signals-dropdown.html",
             "workflow-execution/templates/workflow-variables.html"
         ],
         "notAvailablePage": "workflow-execution/page_not_available_wf_execution.html",

--- a/app/templates_versions/enterprise/subviews.json
+++ b/app/templates_versions/enterprise/subviews.json
@@ -9,6 +9,11 @@
             "modals/result_map_window_wf_automation.html",
             "modals/job_output_window_wf_automation.html",
             "workflow-execution/templates/catalog-view.html",
+            "workflow-execution/templates/job-actions-dropdown.html",
+            "workflow-execution/templates/job-interfaces-dropdown.html",
+            "workflow-execution/templates/job-results-dropdown.html",
+            "workflow-execution/templates/job-service-dropdown.html",
+            "workflow-execution/templates/job-signals-dropdown.html",
             "workflow-execution/templates/workflow-variables.html"
         ],
         "notAvailablePage": "workflow-execution/page_not_available_wf_execution.html",


### PR DESCRIPTION
- Use templates for dropdowns to avoid adding them to the Dom (a dropdown by job !). From now on, they will be loaded on-demand (on-click) and removed from the Dom as soon as they are closed. This represents a big performance improvement because it cuts by a 1/3rd the number of angularjs watchers.