### PR TITLE
Improve dataspace file download using token and reverse upload progress bar

### DIFF
--- a/app/scripts/modals/file-browser-modal-controller.js
+++ b/app/scripts/modals/file-browser-modal-controller.js
@@ -266,23 +266,23 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
     }
 
     $scope.downloadFileRequest = function(filePath, fileName, fileEncoding) {
-        var url = dataspaceRestUrl + encodeURIComponent(filePath) + "?encoding=" + fileEncoding;
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', url, true);
-        xhr.setRequestHeader("sessionid", localStorage['pa.session']);
-        xhr.responseType = 'arraybuffer';
-        xhr.onload = function (e) {
-            if (xhr.status == 200) {
-                var blob = new Blob([this.response]);
-                var a = document.createElement('a');
-                a.href = window.URL.createObjectURL(blob);
-                a.download = fileName;
-                a.click();
-            } else {
-                displayGenericTitleErrorMessage(['Failed to download the file', filePath + ':' + xhr.statusText]);
+        $http({
+            url: JSON.parse(localStorage.restUrl) + "/common/token",
+            method: "POST",
+            headers: {
+                'sessionid': getSessionId()
             }
-        };
-        xhr.send();
+        })
+        .success(function (data){
+            window.location.href = dataspaceRestUrl + encodeURIComponent(filePath) + "?encoding=" + fileEncoding + "&token=" + data;
+        })
+        .error(function (xhr) {
+            var errorMessage = "";
+            if(xhr) {
+                errorMessage = ": "+ xhr;
+            }
+            displayGenericTitleErrorMessage('Failed to be authenticated for downloading the file ' + fileName, errorMessage);
+        });
     }
 
     $scope.deleteFile = function() {

--- a/app/scripts/modals/file-browser-modal-controller.js
+++ b/app/scripts/modals/file-browser-modal-controller.js
@@ -274,7 +274,6 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
             }
         })
         .success(function (data){
-            console.log(data)
             window.location.href = dataspaceRestUrl + encodeURIComponent(filePath) + "?encoding=" + fileEncoding + "&token=" + data[0];
         })
         .error(function (xhr) {

--- a/app/scripts/modals/file-browser-modal-controller.js
+++ b/app/scripts/modals/file-browser-modal-controller.js
@@ -267,14 +267,15 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
 
     $scope.downloadFileRequest = function(filePath, fileName, fileEncoding) {
         $http({
-            url: JSON.parse(localStorage.restUrl) + "/common/token",
+            url: JSON.parse(localStorage.restUrl) + "/common/tokens?numberTokens=1",
             method: "POST",
             headers: {
                 'sessionid': getSessionId()
             }
         })
         .success(function (data){
-            window.location.href = dataspaceRestUrl + encodeURIComponent(filePath) + "?encoding=" + fileEncoding + "&token=" + data;
+            console.log(data)
+            window.location.href = dataspaceRestUrl + encodeURIComponent(filePath) + "?encoding=" + fileEncoding + "&token=" + data[0];
         })
         .error(function (xhr) {
             var errorMessage = "";

--- a/app/scripts/utils.js
+++ b/app/scripts/utils.js
@@ -107,7 +107,7 @@ function UtilsFactory($window, $uibModal, $filter, $cookies, $http, toastr, Swee
             uploadEventHandlers: {
                 progress: function (e) {
                     if (e.lengthComputable) {
-                        uploadProgress = (1 - e.loaded / e.total) * 100;
+                        uploadProgress = (e.loaded / e.total) * 100;
                         uploadToast.el.find('.upload-progress-bar').css('width', uploadProgress + '%');
                     }
                 }
@@ -116,9 +116,8 @@ function UtilsFactory($window, $uibModal, $filter, $cookies, $http, toastr, Swee
         })
         .success(function (data){
             successCallback();
-            uploadToast.el.children().removeClass('toast-info')
-            uploadToast.el.children().addClass('toast-success')
-            uploadToast.el.find('.toast-message').text("Your file " + selectedFile.name + " has been successfully uploaded.");
+            uploadToast.el.remove();
+            toastr.success("Your file " + selectedFile.name + " has been successfully uploaded.", {timeOut: 0, extendedTimeOut: 0});
         })
         .error(function (xhr) {
             errorCallback();
@@ -126,9 +125,8 @@ function UtilsFactory($window, $uibModal, $filter, $cookies, $http, toastr, Swee
             if(xhr) {
                 errorMessage = ": "+ xhr;
             }
-            uploadToast.el.children().removeClass('toast-info')
-            uploadToast.el.children().addClass('toast-error')
-            uploadToast.el.find('.toast-message').text('Failed to upload the file ' + selectedFile.name + errorMessage)
+            uploadToast.el.remove();
+            toastr.error('Failed to upload the file ' + selectedFile.name + errorMessage, {timeOut: 0, extendedTimeOut: 0})
         });
     }
 


### PR DESCRIPTION
- Change to token authentication to use browser download for dataspace file download;
- Reverse the upload progress bar (width as complete percentage instead of remaining percentage);
- Create new notification object for success / error instead of reusing the uploading notification to avoid the user has manually closed the uploading notification.
