### PR TITLE
Improve uploading files dropdown

### DIFF
--- a/app/resources/locales/locale-en.json
+++ b/app/resources/locales/locale-en.json
@@ -4,6 +4,7 @@
   "All rights reserved": "All rights reserved",
   "and": "and",
   "and all the files in it ?": "and all the files in it?",
+  "Are you sure you want to cancel uploading": "Are you sure you want to cancel uploading",
   "Are you sure you want to permanently delete the file": "Are you sure you want to permanently delete the file",
   "Are you sure you want to permanently delete the folder": "Are you sure you want to permanently delete the folder",
   "as a zip archive": "as a zip archive",
@@ -73,6 +74,7 @@
   "Select one": "Select one",
   "Settings": "Settings",
   "Show Hidden": "Show Hidden",
+  "Show the hidden files and folders which start with a dot character": "Show the hidden files and folders which start with a dot character",
   "Size": "Size",
   "The access is not authorized": "The access is not authorized",
   "Tutorials": "Tutorials",
@@ -91,6 +93,7 @@
   "Yes, delete file!": "Yes, delete file!",
   "Yes, delete folder!": "Yes, delete folder!",
   "Yes, download it!": "Yes, download it!",
+  "Yes, stop uploading!": "Yes, stop uploading!",
   "You are about to download the folder": "You are about to download the folder",
   "Your": "Your"
 }

--- a/app/resources/locales/locale-en.json
+++ b/app/resources/locales/locale-en.json
@@ -74,7 +74,7 @@
   "Select one": "Select one",
   "Settings": "Settings",
   "Show Hidden": "Show Hidden",
-  "Show the hidden files and folders which start with a dot character": "Show the hidden files and folders which start with a dot character",
+  "Show the hidden files and folders": "Show the hidden files and folders",
   "Size": "Size",
   "The access is not authorized": "The access is not authorized",
   "Tutorials": "Tutorials",

--- a/app/resources/locales/locale-es.json
+++ b/app/resources/locales/locale-es.json
@@ -74,7 +74,7 @@
   "Select one": "Seleccione uno",
   "Settings": "Configuración",
   "Show Hidden": "Mostrar oculto",
-  "Show the hidden files and folders which start with a dot character": "Muestra los archivos y carpetas ocultos que comienzan con un carácter de punto",
+  "Show the hidden files and folders": "Mostrar los archivos y carpetas ocultos",
   "Size": "Tamaño",
   "The access is not authorized": "No se permite el acceso",
   "Tutorials": "Tutoriales",

--- a/app/resources/locales/locale-es.json
+++ b/app/resources/locales/locale-es.json
@@ -4,6 +4,7 @@
   "All rights reserved": "Todos los derechos reservados",
   "and": "y",
   "and all the files in it ?": "y todos los archivos que contiene?",
+  "Are you sure you want to cancel uploading": "Estas seguro que quieres cancelar la carga",
   "Are you sure you want to permanently delete the file": "¿Estás seguro de que quieres eliminar el archivo de forma permanente?",
   "Are you sure you want to permanently delete the folder": "¿Estás seguro de que quieres eliminar permanentemente la carpeta  y todos los archivos que contiene?",
   "as a zip archive": "en un archivo zip",
@@ -73,6 +74,7 @@
   "Select one": "Seleccione uno",
   "Settings": "Configuración",
   "Show Hidden": "Mostrar oculto",
+  "Show the hidden files and folders which start with a dot character": "Muestra los archivos y carpetas ocultos que comienzan con un carácter de punto",
   "Size": "Tamaño",
   "The access is not authorized": "No se permite el acceso",
   "Tutorials": "Tutoriales",
@@ -91,6 +93,7 @@
   "Yes, delete file!": "¡Sí, eliminar archivo!",
   "Yes, delete folder!": "¡Sí, eliminar carpeta!",
   "Yes, download it!": "¡Sí, descarga!",
+  "Yes, stop uploading!": "Sí, parada de la carga!",
   "You are about to download the folder": "Estás a punto de descargar la carpeta",
   "Your": "Tu"
 }

--- a/app/resources/locales/locale-es.json
+++ b/app/resources/locales/locale-es.json
@@ -4,7 +4,7 @@
   "All rights reserved": "Todos los derechos reservados",
   "and": "y",
   "and all the files in it ?": "y todos los archivos que contiene?",
-  "Are you sure you want to cancel uploading": "Estas seguro que quieres cancelar la carga",
+  "Are you sure you want to cancel uploading": "¿Estás seguro que quieres cancelar la carga",
   "Are you sure you want to permanently delete the file": "¿Estás seguro de que quieres eliminar el archivo de forma permanente?",
   "Are you sure you want to permanently delete the folder": "¿Estás seguro de que quieres eliminar permanentemente la carpeta  y todos los archivos que contiene?",
   "as a zip archive": "en un archivo zip",

--- a/app/resources/locales/locale-fr.json
+++ b/app/resources/locales/locale-fr.json
@@ -74,7 +74,7 @@
   "Select one": "Sélectionnez un",
   "Settings": "Paramètres",
   "Show Hidden": "Afficher les fichiers cachés",
-  "Show the hidden files and folders which start with a dot character": "Afficher les fichiers et dossiers cachés qui commencent par un caractère point",
+  "Show the hidden files and folders": "Afficher les fichiers et dossiers cachés",
   "Size": "Taille",
   "The access is not authorized": "L'accès n'est pas autorisé",
   "Tutorials": "Tutoriels",

--- a/app/resources/locales/locale-fr.json
+++ b/app/resources/locales/locale-fr.json
@@ -4,6 +4,7 @@
   "All rights reserved": "Tous droits réservés",
   "and": "et",
   "and all the files in it ?": "et tous les fichiers qu'il contient?",
+  "Are you sure you want to cancel uploading": "Voulez-vous vraiment annuler le téléchargement",
   "Are you sure you want to permanently delete the file": "Voulez-vous vraiment supprimer définitivement le fichier",
   "Are you sure you want to permanently delete the folder": "Voulez-vous vraiment supprimer définitivement le dossier",
   "as a zip archive": "en tant qu'archive zip",
@@ -73,6 +74,7 @@
   "Select one": "Sélectionnez un",
   "Settings": "Paramètres",
   "Show Hidden": "Afficher les fichiers cachés",
+  "Show the hidden files and folders which start with a dot character": "Afficher les fichiers et dossiers cachés qui commencent par un caractère point",
   "Size": "Taille",
   "The access is not authorized": "L'accès n'est pas autorisé",
   "Tutorials": "Tutoriels",
@@ -91,6 +93,7 @@
   "Yes, delete file!": "Oui, supprimez le fichier!",
   "Yes, delete folder!": "Oui, supprimez le dossier!",
   "Yes, download it!": "Oui, téléchargez-le!",
+  "Yes, stop uploading!": "Oui, arrêtez de télécharger!",
   "You are about to download the folder": "Vous êtes sur le point de télécharger le dossier",
   "Your": "Votre"
 }

--- a/app/resources/locales/locale-pt.json
+++ b/app/resources/locales/locale-pt.json
@@ -4,6 +4,7 @@
   "All rights reserved": "Todos os direitos reservados",
   "and": "e",
   "and all the files in it ?": "e todos os arquivos?",
+  "Are you sure you want to cancel uploading": "Tem certeza de que deseja cancelar o upload",
   "Are you sure you want to permanently delete the file": "Tem certeza de que deseja excluir permanentemente o arquivo?",
   "Are you sure you want to permanently delete the folder": "Tem certeza de que deseja excluir permanentemente a pasta e todos os arquivos?",
   "as a zip archive": "como um arquivo zip",
@@ -73,6 +74,7 @@
   "Select one": "Selecione um",
   "Settings": "Paramêtros",
   "Show Hidden": "Mostrar Oculto",
+  "Show the hidden files and folders which start with a dot character": "Mostra os arquivos e pastas ocultos que começam com um caractere de ponto",
   "Size": "Tamanho",
   "The access is not authorized": "acesso não é permitido",
   "Tutorials": "Tutoriais",
@@ -91,6 +93,7 @@
   "Yes, delete file!": "Sim, exclua o arquivo!",
   "Yes, delete folder!": "Sim, exclua a pasta!",
   "Yes, download it!": "Sim, baixe a pasta",
+  "Yes, stop uploading!": "Sim, pare de enviar!",
   "You are about to download the folder": "Você está prestes a baixar a pasta",
   "Your": "Seu"
 }

--- a/app/resources/locales/locale-pt.json
+++ b/app/resources/locales/locale-pt.json
@@ -74,7 +74,7 @@
   "Select one": "Selecione um",
   "Settings": "Paramêtros",
   "Show Hidden": "Mostrar Oculto",
-  "Show the hidden files and folders which start with a dot character": "Mostra os arquivos e pastas ocultos que começam com um caractere de ponto",
+  "Show the hidden files and folders": "Mostra os arquivos e pastas ocultos",
   "Size": "Tamanho",
   "The access is not authorized": "acesso não é permitido",
   "Tutorials": "Tutoriais",

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -327,6 +327,14 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         $scope.firstAccessiblePortal = '';
         $rootScope.errorMessage = undefined;
         $scope.portalsAccessPermission = {};
+        $rootScope.uploadingCancelers.forEach(function (upload, uploadId){
+            if (upload && upload.canceler) {
+                upload.canceler.promise.status = 499; // Set 499 status to flag cancelled http requests
+                upload.canceler.resolve()
+            }
+        })
+        $rootScope.uploadingCancelers.clear();
+        $rootScope.uploadingFiles.length = 0;
         localStorage.removeItem('pa.session');
         $scope.stopRegularCheckSession();
         $rootScope.$broadcast('event:StopRefreshing');

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -327,6 +327,8 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         $scope.firstAccessiblePortal = '';
         $rootScope.errorMessage = undefined;
         $scope.portalsAccessPermission = {};
+
+        // cancel the in-progress uploading dataspace files
         $rootScope.uploadingCancelers.forEach(function (upload, uploadId){
             if (upload && upload.canceler) {
                 upload.canceler.promise.status = 499; // Set 499 status to flag cancelled http requests
@@ -335,6 +337,7 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         })
         $rootScope.uploadingCancelers.clear();
         $rootScope.uploadingFiles.length = 0;
+
         localStorage.removeItem('pa.session');
         $scope.stopRegularCheckSession();
         $rootScope.$broadcast('event:StopRefreshing');

--- a/app/views/modals/dataspace-file-browser.html
+++ b/app/views/modals/dataspace-file-browser.html
@@ -44,7 +44,7 @@
                     <div class="progress-bgd" ng-style="{'width':$root.totalProgress+'%'}"></div>
                     <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" template-url="views/modals/uploading-files-dropdown.html"></ul>
                 </div>
-                <label class="checkbox-inline" uib-tooltip="{{'Show the hidden files and folders which start with a dot character'|translate}}"><input id="show-hidden-files" type="checkbox" ng-model="showHiddenFiles" ng-change="showHiddenFilesChange()">{{'Show Hidden'|translate}}</label>
+                <label class="checkbox-inline" uib-tooltip="{{'Show the hidden files and folders'|translate}}"><input id="show-hidden-files" type="checkbox" ng-model="showHiddenFiles" ng-change="showHiddenFilesChange()">{{'Show Hidden'|translate}}</label>
             </div>
         </div>
         <br>

--- a/app/views/modals/dataspace-file-browser.html
+++ b/app/views/modals/dataspace-file-browser.html
@@ -38,13 +38,13 @@
                         </div>
                         <div>
                             <i class="fa fa-clock-o"></i>
-                            <span>{{($root.totalRemainTime) ? ($root.totalRemainTime | durationFormat) : "--:--"}} {{'left'|translate}}</span>
+                            <span class="m-r-sm">{{($root.totalRemainTime) ? ($root.totalRemainTime | durationFormat) : "--:--"}} {{'left'|translate}}</span>
                         </div>
                     </button>
                     <div class="progress-bgd" ng-style="{'width':$root.totalProgress+'%'}"></div>
                     <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" template-url="views/modals/uploading-files-dropdown.html"></ul>
                 </div>
-                <label class="checkbox-inline"><input id="show-hidden-files" type="checkbox" ng-model="showHiddenFiles" ng-change="showHiddenFilesChange()">{{'Show Hidden'|translate}}</label>
+                <label class="checkbox-inline" uib-tooltip="{{'Show the hidden files and folders which start with a dot character'|translate}}"><input id="show-hidden-files" type="checkbox" ng-model="showHiddenFiles" ng-change="showHiddenFilesChange()">{{'Show Hidden'|translate}}</label>
             </div>
         </div>
         <br>

--- a/app/views/modals/uploading-files-dropdown.html
+++ b/app/views/modals/uploading-files-dropdown.html
@@ -3,11 +3,11 @@
         <div class="container-flex w-100">
             <span ng-if="upload.isGlobalFile" class="fa-stack fa-xs m-r-xs p-w-sm" aria-hidden="true">
                 <i class="fa fa-folder fa-stack-2x"></i>
-                <i class="fa fa-globe fa-stack-1x fa-inverse dataspace-icon"></i>
+                <i class="fa fa-globe fa-stack-1x fa-inverse"></i>
             </span>
             <span ng-if="!upload.isGlobalFile" class="fa-stack fa-xs m-r-xs p-w-sm" aria-hidden="true">
                 <i class="fa fa-folder fa-stack-2x"></i>
-                <i class="fa fa-user fa-stack-1x fa-inverse dataspace-icon"></i>
+                <i class="fa fa-user fa-stack-1x fa-inverse"></i>
             </span>
             <span class="w-100 m-r-xl font-bold">{{upload.filename}}</span>
             <div class="pull-right container-flex">

--- a/app/views/modals/uploading-files-dropdown.html
+++ b/app/views/modals/uploading-files-dropdown.html
@@ -1,6 +1,14 @@
 <ul uib-dropdown-menu role="menu" class="dropdown-menu dropdown-menu-right custom-dropdown pull-right" style="min-width: 500px">
     <li ng-repeat="upload in $root.uploadingFiles" class="uploading-file-item {{upload.id}} p-sm">
         <div class="container-flex w-100">
+            <span ng-if="upload.isGlobalFile" class="fa-stack fa-xs m-r-smdd" aria-hidden="true" style="padding-right: 50px">
+                <i class="fa fa-folder fa-stack-2x"></i>
+                <i class="fa fa-globe fa-stack-1x fa-inverse dataspace-icon"></i>
+            </span>
+            <span ng-if="!upload.isGlobalFile" class="fa-stack fa-xs m-r-smdd" aria-hidden="true" style="padding-right: 50px">
+                <i class="fa fa-folder fa-stack-2x"></i>
+                <i class="fa fa-user fa-stack-1x fa-inverse dataspace-icon"></i>
+            </span>
             <span class="w-100 m-r-xl font-bold">{{upload.filename}}</span>
             <div class="pull-right container-flex">
                 <span class="upload-progress m-r-sm" style="white-space: nowrap;">{{upload.size}}</span>

--- a/app/views/modals/uploading-files-dropdown.html
+++ b/app/views/modals/uploading-files-dropdown.html
@@ -1,11 +1,11 @@
 <ul uib-dropdown-menu role="menu" class="dropdown-menu dropdown-menu-right custom-dropdown pull-right" style="min-width: 500px">
     <li ng-repeat="upload in $root.uploadingFiles" class="uploading-file-item {{upload.id}} p-sm">
         <div class="container-flex w-100">
-            <span ng-if="upload.isGlobalFile" class="fa-stack fa-xs m-r-smdd" aria-hidden="true" style="padding-right: 50px">
+            <span ng-if="upload.isGlobalFile" class="fa-stack fa-xs m-r-xs p-w-sm" aria-hidden="true">
                 <i class="fa fa-folder fa-stack-2x"></i>
                 <i class="fa fa-globe fa-stack-1x fa-inverse dataspace-icon"></i>
             </span>
-            <span ng-if="!upload.isGlobalFile" class="fa-stack fa-xs m-r-smdd" aria-hidden="true" style="padding-right: 50px">
+            <span ng-if="!upload.isGlobalFile" class="fa-stack fa-xs m-r-xs p-w-sm" aria-hidden="true">
                 <i class="fa fa-folder fa-stack-2x"></i>
                 <i class="fa fa-user fa-stack-1x fa-inverse dataspace-icon"></i>
             </span>


### PR DESCRIPTION
- Clean uploading files when closeSession to avoid security issue of exposing uploading files to unauthenticated user; 
- Identify the uploading files is global/user space file; 
- Add confirmation for cancel uploading; 
- Remove annoying error message for canceled upload; 
- The total remain time of uploading files should base on max instead of sum of all uploads remain time;
- Add close button for the toastr notification ; 
- Add tooltips for show hidden; 
- Enable ESC key to close file browser modal; 
- Add space before dropdown triangle.