### PR TITLE
Support to add multi-lines credential value in 3rd-party-credential modal

### DIFF
--- a/app/resources/locales/locale-en.json
+++ b/app/resources/locales/locale-en.json
@@ -70,6 +70,7 @@
   "Location": "Location",
   "login": "login",
   "Manage third-party credentials": "Manage third-party credentials",
+  "Multiline credential": "Multiline credential",
   "Name": "Name",
   "New folder": "New folder",
   "No file chosen to be downloaded.": "No file chosen to be downloaded.",

--- a/app/resources/locales/locale-es.json
+++ b/app/resources/locales/locale-es.json
@@ -70,6 +70,7 @@
   "Location": "Ubicación",
   "login": "conectarse",
   "Manage third-party credentials": "Administrar credenciales de terceros",
+  "Multiline credential": "Credencial multilínea",
   "Name": "Nombre",
   "New folder": "Nueva carpeta",
   "No file chosen to be downloaded.": "No se eligió ningún archivo para descargar.",

--- a/app/resources/locales/locale-fr.json
+++ b/app/resources/locales/locale-fr.json
@@ -73,6 +73,7 @@
   "Location": "Emplacement",
   "login": "Authentification",
   "Manage third-party credentials": "Gérer les identités tierces",
+  "Multiline credential": "Identité multiligne",
   "Name": "Nom",
   "New folder": "Nouveau dossier",
   "No file chosen to be downloaded.": "Aucun fichier choisi pour être téléchargé.",

--- a/app/resources/locales/locale-pt.json
+++ b/app/resources/locales/locale-pt.json
@@ -71,6 +71,7 @@
   "Location": "Localização",
   "login": "conectar",
   "Manage third-party credentials": "Gerenciar credenciais de terceiros",
+  "Multiline credential": "Credencial multilinha",
   "Name": "Nome",
   "New folder": "Nova pasta",
   "No file chosen to be downloaded.": "Nenhum arquivo escolhido para download.",

--- a/app/scripts/modals/third-party-credential-modal-controller.js
+++ b/app/scripts/modals/third-party-credential-modal-controller.js
@@ -31,6 +31,16 @@ angular.module('workflow-variables', []).controller('ThirdPartyCredentialModalCt
             });
     }
 
+    $scope.changeMultilineCredential = function() {
+        if ($scope.showMultilineCred) {
+            $('#new-cred-value').hide();
+            $('#new-cred-value-multiline').show();
+        } else {
+            $('#new-cred-value').show();
+            $('#new-cred-value-multiline').hide();
+        }
+    }
+
     $scope.cancel = function () {
         $uibModalInstance.dismiss('cancel');
     }

--- a/app/views/modals/third_party_credentials.html
+++ b/app/views/modals/third_party_credentials.html
@@ -36,8 +36,8 @@
                 <table id="add-3rd-party-cred-table" style="margin-top: 25px">
                     <tr>
                         <td width="25%"><label for="new-cred-key">{{'Key'|translate}}:</label></td>
-                        <td width="35%"><label for="new-cred-value">{{'Credential'|translate}}:</label></td>
-                        <td width="35%"></td>
+                        <td width="30%"><label for="new-cred-value">{{'Credential'|translate}}:</label></td>
+                        <td width="40%"></td>
                         <td width="5%"></td>
                     </tr>
                     <tr>
@@ -52,7 +52,10 @@
                             <textarea class="textareavalues form-control" id="new-cred-value-multiline" name="credValue" ng-model="credValue" style="display:none;" rows="1"></textarea>
                         </td>
                         <td>
-                            <label for="multiline-cred" style="display:inline;"><input type="checkbox" id="multiline-cred" ng-model="showMultilineCred" ng-change="changeMultilineCredential()" style="vertical-align:top;" />Multiline credential</label>
+                            <label for="multiline-cred" style="display:inline;">
+                                <input type="checkbox" id="multiline-cred" ng-model="showMultilineCred" ng-change="changeMultilineCredential()" style="vertical-align:top;" />
+                                {{'Multiline credential'|translate}}
+                            </label>
                         </td>
                         <td>
                             <button id="add-third-party-credential-button" class="btn btn-success"> {{'Add'|translate}}

--- a/app/views/modals/third_party_credentials.html
+++ b/app/views/modals/third_party_credentials.html
@@ -35,9 +35,10 @@
                   ng-submit="addThirdPartyCredential(credKey, credValue)">
                 <table id="add-3rd-party-cred-table" style="margin-top: 25px">
                     <tr>
-                        <td width="40%"><label for="new-cred-key">{{'Key'|translate}}:</label></td>
-                        <td width="40%"><label for="new-cred-value">{{'Credential'|translate}}:</label></td>
-                        <td width="20%"></td>
+                        <td width="25%"><label for="new-cred-key">{{'Key'|translate}}:</label></td>
+                        <td width="35%"><label for="new-cred-value">{{'Credential'|translate}}:</label></td>
+                        <td width="35%"></td>
+                        <td width="5%"></td>
                     </tr>
                     <tr>
                         <td>
@@ -45,8 +46,14 @@
                                    class="textareavalues form-control" required pattern=".*\S+.*"
                                    title="{{'The credential key should not contain only white spaces.'|translate}}"/>
                         </td>
-                        <td><input type="password" id="new-cred-value" name="credValue" ng-model="credValue"
-                                   class="textareavalues form-control" autocomplete="new-password"/></td>
+                        <td>
+                            <input type="password" id="new-cred-value" name="credValue" ng-model="credValue"
+                                   class="textareavalues form-control" autocomplete="new-password"/>
+                            <textarea class="textareavalues form-control" id="new-cred-value-multiline" name="credValue" ng-model="credValue" style="display:none;" rows="1"></textarea>
+                        </td>
+                        <td>
+                            <label for="multiline-cred" style="display:inline;"><input type="checkbox" id="multiline-cred" ng-model="showMultilineCred" ng-change="changeMultilineCredential()" style="vertical-align:top;" />Multiline credential</label>
+                        </td>
                         <td>
                             <button id="add-third-party-credential-button" class="btn btn-success"> {{'Add'|translate}}
                             </button>


### PR DESCRIPTION
In the modal of managing 3rd-party-credentials when submitting a workflow with PA:CREDENTIAL variables, add a checkbox "Multiline credential" to allow the user to input the multi-lines credential value by switching between the password input (for single line credential) and textarea (for multi-lines credential). 