### PR TITLE
fix the bug of uploading files in the debug info disabled environment.

### DIFF
--- a/app/scripts/directives.js
+++ b/app/scripts/directives.js
@@ -352,6 +352,23 @@ function showDropdownFromTemplate($document, $timeout, $uibPosition) {
 }
 
 /**
+* Upload the file, call the function specified in "input-file-change" attribute on change event.
+*/
+function inputFileChange($parse, $timeout) {
+    return {
+        restrict: 'A',
+        link: function (scope, element, attrs) {
+            var onChangeHandler = $parse(attrs.inputFileChange);
+            element.bind('change', function() {
+                $timeout (function () {
+                    onChangeHandler(scope);
+                });
+            });
+        }
+    };
+}
+
+/**
  * Displays a tooltip that shows the whole text of a truncated element (by ellipsis or else)
  * Requires using a "tooltip-enable=true" attribute and set by default to true.
  * @returns {{link: link, restrict: string}}
@@ -402,4 +419,5 @@ angular
     .directive('slimScroll', slimScroll)
     .directive('backTop', backToTop)
     .directive('showDropdownFromTemplate', showDropdownFromTemplate)
+    .directive('inputFileChange', inputFileChange)
     .directive('ellipsisTooltip', ellipsisTooltip);

--- a/app/scripts/modals/file-browser-modal-controller.js
+++ b/app/scripts/modals/file-browser-modal-controller.js
@@ -172,9 +172,9 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
     }
 
     $scope.fileSelected = function() {
-        var files = event.target.files;
-        if (files && files.length) {
-            var selectedFile = files[0];
+        var element = document.getElementById('selected-upload-file');
+        var selectedFile = element.files[0];
+        if (selectedFile) {
             var pathname = $scope.currentPath + selectedFile.name;
             if (selectedFile.name.includes(':')) {
                 UtilsFactory.displayTranslatedErrorMessage('Oops!!!', ['Failed to upload the file ', selectedFile.name, ':', 'it should not contain colon.']);
@@ -187,7 +187,7 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
                 }, function () {});
         }
         // clean up the value to allow the user to upload twice the file with same name, otherwise the function won't be triggered.
-        event.target.value = '';
+        element.value = '';
     }
 
     $scope.createFolder = function() {
@@ -363,20 +363,3 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
 
     $scope.refreshFiles();
 });
-
-function inputFileChange($parse) {
-    return {
-        restrict: 'A',
-        link: function (scope, element, attrs) {
-            var onChangeHandler = $parse(attrs.inputFileChange);
-            element.bind('change', function() {
-                scope.$apply(function() {
-                    onChangeHandler(scope);
-                })
-            });
-        }
-    };
-}
-
-angular.module('workflow-variables')
-    .directive('inputFileChange', inputFileChange);

--- a/app/scripts/modals/file-browser-modal-controller.js
+++ b/app/scripts/modals/file-browser-modal-controller.js
@@ -171,9 +171,10 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
         $('#selected-upload-file').click();
     }
 
-    $scope.fileSelected = function(files) {
-        var selectedFile = files[0];
-        if (selectedFile) {
+    $scope.fileSelected = function() {
+        var files = event.target.files;
+        if (files && files.length) {
+            var selectedFile = files[0];
             var pathname = $scope.currentPath + selectedFile.name;
             if (selectedFile.name.includes(':')) {
                 UtilsFactory.displayTranslatedErrorMessage('Oops!!!', ['Failed to upload the file ', selectedFile.name, ':', 'it should not contain colon.']);
@@ -185,6 +186,8 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
                     $scope.refreshFiles();
                 }, function () {});
         }
+        // clean up the value to allow the user to upload twice the file with same name, otherwise the function won't be triggered.
+        event.target.value = '';
     }
 
     $scope.createFolder = function() {
@@ -360,3 +363,20 @@ angular.module('workflow-variables').controller('FileBrowserModalCtrl', function
 
     $scope.refreshFiles();
 });
+
+function inputFileChange($parse) {
+    return {
+        restrict: 'A',
+        link: function (scope, element, attrs) {
+            var onChangeHandler = $parse(attrs.inputFileChange);
+            element.bind('change', function() {
+                scope.$apply(function() {
+                    onChangeHandler(scope);
+                })
+            });
+        }
+    };
+}
+
+angular.module('workflow-variables')
+    .directive('inputFileChange', inputFileChange);

--- a/app/templates_versions/common/app.js
+++ b/app/templates_versions/common/app.js
@@ -2,7 +2,7 @@
  * INSPINIA - Responsive Admin Theme
  *
  */
-(function () {
+(function() {
     angular.module('inspinia', [
         'ui.router', // Routing
         'ui.bootstrap', // Bootstrap
@@ -27,20 +27,20 @@
         'gantt.corner'
     ])
         .config(['momentPickerProvider',
-            function (momentPickerProvider) {
+            function(momentPickerProvider) {
                 momentPickerProvider.options({
                     minutesFormat: 'HH:mm'
                 });
             }
         ])
         .config(['calendarConfig',
-            function (calendarConfig) {
+            function(calendarConfig) {
                 calendarConfig.allDateFormats.moment.date.hour = 'HH:mm';
                 calendarConfig.showTimesOnWeekView = true;
             }
         ])
         .config(['$compileProvider',
-            function ($compileProvider) {
+            function($compileProvider) {
                 $compileProvider.debugInfoEnabled(false);
             }
         ]);

--- a/app/templates_versions/common/config.js
+++ b/app/templates_versions/common/config.js
@@ -45,14 +45,14 @@ function config($stateProvider, $urlRouterProvider) {
 angular
     .module('inspinia')
     .config(config)
-    .run(function ($rootScope, $state, $interval, $http, $location) {
+    .run(function($rootScope, $state, $interval, $http, $location) {
         $rootScope.$state = $state;
         $rootScope.$interval = $interval;
     });
 
 angular
     .module('inspinia')
-    .config(function ($httpProvider) {
+    .config(function($httpProvider) {
         $httpProvider.defaults.headers.common = {};
         $httpProvider.defaults.headers.post = {};
         $httpProvider.defaults.headers.put = {};
@@ -64,13 +64,13 @@ angular
 
 angular
     .module('inspinia')
-    .run(function ($rootScope, $state, $http, $location) {
-        $rootScope.$on('$locationChangeStart', function (event) {
+    .run(function($rootScope, $state, $http, $location) {
+        $rootScope.$on('$locationChangeStart', function(event) {
             if (!localStorage['pcaServiceUrl'] || !localStorage['schedulerRestUrl'] || !localStorage['notificationServiceUrl'] || !localStorage['catalogServiceUrl'] || !localStorage['appCatalogWorkflowsUrl'] || !localStorage['appCatalogBucketsUrl'] || !localStorage['configViews'] || !localStorage['rmRestUrl'] || !localStorage['restUrl']) {
                 getProperties($http, $location);
             }
             var myDataPromise = isSessionValide($http, getSessionId(), $location);
-            myDataPromise.then(function (result) {
+            myDataPromise.then(function(result) {
                 if (!result && $location.$$url != '/login') {
                     event.preventDefault();
                     $rootScope.$broadcast('event:StopRefreshing');

--- a/app/views/modals/dataspace-file-browser.html
+++ b/app/views/modals/dataspace-file-browser.html
@@ -19,7 +19,7 @@
             <button id="new-folder-btn" uib-tooltip="{{'New folder'|translate}}" class="btn btn-white"  ng-click="createFolder()">
                 <i class="fa fa fa-plus"></i>
             </button>
-            <input type="file" id="selected-upload-file"  onchange="angular.element(this).scope().fileSelected(this.files)" class="hidden" />
+            <input type="file" id="selected-upload-file"  input-file-change="fileSelected()" class="hidden" />
             <button id="upload-file-btn" uib-tooltip="{{'Upload a file'|translate}}" class="btn btn-white" ng-click="clickUpload()">
                 <i class="fa fa-upload"></i>
             </button>


### PR DESCRIPTION
The file uploading feature is recently broken because now the debug info is disabled (https://github.com/ow2-proactive/automation-dashboard/blob/master/app/templates_versions/common/app.js#L44), so the input #selected-upload-file can no longer access the scope with the current way. 
ref: https://github.com/angular/angular.js/issues/9515

This PR aims to fix this problem by creating a custom directive `input-file-change` to pass the scope without debug info.