### PR TITLE
To cherry-pick : fix gradle install

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,11 @@ uploadArchives {
     }
 }
 
+jar {
+    manifest {
+    }
+}
+
 task packageDist(type: Zip) {
     from 'dist'
     dependsOn grunt_build
@@ -219,3 +224,6 @@ grunt_build.dependsOn 'npmInstall'
 
 // runs "grunt build" as part of your gradle build
 build.dependsOn grunt_build
+
+jar.mustRunAfter packageDist
+install.dependsOn jar

--- a/build.gradle
+++ b/build.gradle
@@ -225,5 +225,6 @@ grunt_build.dependsOn 'npmInstall'
 // runs "grunt build" as part of your gradle build
 build.dependsOn grunt_build
 
+// force building the jar before the install task (needed for release project)
 jar.mustRunAfter packageDist
 install.dependsOn jar


### PR DESCRIPTION
jar was probably removed by one of the node or grunt tasks. To fix this, force building the jar just before doing the install task.