### PR TITLE
Move ui-grid import to main controller

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -2,7 +2,7 @@
  * Created by ActiveEon Team on 18/04/2017.
  */
 
-var mainModule = angular.module('main', ['ngResource', 'spring-data-rest', 'angular-toArrayFilter', 'oitozero.ngSweetAlert', 'ngSanitize', 'pascalprecht.translate']);
+var mainModule = angular.module('main', ['ngResource', 'spring-data-rest', 'angular-toArrayFilter', 'oitozero.ngSweetAlert', 'ngSanitize', 'pascalprecht.translate', 'ui.grid', 'ui.grid.resizeColumns', 'ui.grid.selection', 'ui.grid.exporter', 'ui.grid.moveColumns', 'ui.grid.pinning', 'ui.grid.autoResize',]);
 
 function getSessionId() {
     return localStorage['pa.session'];


### PR DESCRIPTION
Move ui-grid import declaration to the main controller to make it available in both JA and catalog.
This is the only way to import ui-grid without making it conflict with itself if imported separately in different sub-portals.