### PR TITLE
Disable closing the context-menu when using mouse scroll. 

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -390,8 +390,13 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         }
     }
 
-    $scope.hideContextualMenu = function () {
-        $scope.contextDisplay = false;
+    $scope.hideContextualMenu = function (event) {
+        if (!event) {
+            // It's a scroll event
+            return;
+        } else {
+            $scope.contextDisplay = false;
+        }
     };
 
     // Check if position match with the position set by displayContextualMenu

--- a/app/views/common/content.html
+++ b/app/views/common/content.html
@@ -1,5 +1,5 @@
 <!-- Wrapper-->
-<div id="wrapper" style="background-color: #002d66" ng-click="hideContextualMenu()" ng-wheel="hideContextualMenu()" ng-controller="navBarController">
+<div id="wrapper" style="background-color: #002d66" ng-click="hideContextualMenu($event)" ng-wheel="hideContextualMenu($event)" ng-controller="navBarController">
 
     <!-- Page wrapper -->
     <div ng-include="'views/common/topnavbar.html'"></div>


### PR DESCRIPTION
This allows using the context menu's sub menu item with a scroll bar