### PR TITLE
disconnect-user-when-logging-out

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -362,7 +362,6 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         var disconnectUrlPrefix = JSON.parse(localStorage.schedulerRestUrl) + 'disconnect';
         $http.put(disconnectUrlPrefix, null, { headers: {'sessionid': getSessionId() }})
             .then(function (response) {
-                console.log("User is disconnected");
             })
             .catch(function (response) {
                 console.error('Error while disconnecting:', response);

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -358,6 +358,17 @@ mainModule.controller('mainController', function ($window, $http, $scope, $rootS
         $rootScope.$broadcast('event:StopRefreshing');
     };
 
+    $scope.disconnect = function () {
+        var disconnectUrlPrefix = JSON.parse(localStorage.schedulerRestUrl) + 'disconnect';
+        $http.put(disconnectUrlPrefix, null, { headers: {'sessionid': getSessionId() }})
+            .then(function (response) {
+                console.log("User is disconnected");
+            })
+            .catch(function (response) {
+                console.error('Error while disconnecting:', response);
+            });
+    };
+
     $scope.displayContextualMenu = function (clickEvent, position, isWEJobRowContextMenu, data) {
             clickEvent.stopPropagation();
             $scope.contextPosition = position;
@@ -668,6 +679,7 @@ mainModule.controller('loginController', function ($scope, $http, $state, permis
 
 mainModule.controller('logoutController', function ($scope, $state) {
     $scope.logout = function () {
+        $scope.disconnect();
         $scope.closeSession();
     };
 });


### PR DESCRIPTION
After logging out, AD did not send the disconnect request in order to invalidate the sesssionId like the other portals do. 
When logging out, AD just removed “pa.session“ from the local storage. 
So when the user logs out from AD, scheduler and RM can continue to send requests with the same sessionId because it is valid.
Studio portal logs out because it verifies if the “pa.session“ is removed.